### PR TITLE
Fix for "&" in subtitles

### DIFF
--- a/mythroku/mythtv.php
+++ b/mythroku/mythtv.php
@@ -9,6 +9,7 @@ print "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
 	  <banner_ad sd_img=\"" . $WebServer . "/" . $MythRokuDir . "/images/mythtv_logo_SD.png\" hd_img=\"" . $WebServer . "/" . $MythRokuDir . "/images/mythtv_logo_SD.png\"/>
 
 	<category title=\"TV\" description=\"MythTV TV\" sd_img=\"" . $WebServer . "/" . $MythRokuDir . "/images/Mythtv_tv.png\" hd_img=\"" . $WebServer . "/" . $MythRokuDir . "/images/Mythtv_tv.png\">
+		<categoryLeaf title=\"Record Group\" description=\"\" feed=\"" . $WebServer . "/" . $MythRokuDir . "/mythtv_tv_xml.php?sort=recgroup\"/> 
 		<categoryLeaf title=\"Date\" description=\"\" feed=\"" . $WebServer . "/" . $MythRokuDir . "/mythtv_tv_xml.php?sort=date\"/> 
 		<categoryLeaf title=\"Title\" description=\"\" feed=\"" . $WebServer . "/" . $MythRokuDir . "/mythtv_tv_xml.php?sort=title\"/> 
 		<categoryLeaf title=\"Genre\" description=\"\" feed=\"" . $WebServer . "/" . $MythRokuDir . "/mythtv_tv_xml.php?sort=genre\"/> 

--- a/mythroku/mythtv_tv_xml.php
+++ b/mythroku/mythtv_tv_xml.php
@@ -17,6 +17,8 @@ if ($db_found) {
 		$SQL = "SELECT * FROM recorded ORDER BY starttime DESC";
 	}elseif (isset($_GET['sort']) && $_GET['sort'] == 'title'){
 		$SQL = "SELECT * FROM recorded ORDER BY title ASC";
+	}elseif (isset($_GET['sort']) && $_GET['sort'] == 'recgroup'){
+		$SQL = "SELECT * FROM recorded ORDER BY recgroup ASC";
 	}elseif (isset($_GET['sort']) && $_GET['sort'] == 'genre'){
 		$SQL = "SELECT * FROM recorded ORDER BY category ASC";
 	}elseif (isset($_GET['sort']) && $_GET['sort'] == 'channel'){

--- a/mythroku/mythtv_tv_xml.php
+++ b/mythroku/mythtv_tv_xml.php
@@ -73,7 +73,7 @@ while ($db_field = mysql_fetch_assoc($result)) {
 			</media>
 			<synopsis>" . htmlspecialchars(preg_replace('/[^(\x20-\x7F)]*/','', $db_field['description'] )) . "</synopsis>
 			<genres>" . $db_field['category'] . "</genres>
-			<subtitle>" . $db_field['subtitle'] . "</subtitle>
+			<subtitle>" . htmlspecialchars(preg_replace('/[^(\x20-\x7F)]*/','', $db_field['subtitle'] )) . "</subtitle>
 			<runtime>" . $ShowLength . "</runtime>
 			<date>" . date("F j, Y, g:i a", convert_datetime($db_field['starttime'])) . "</date>
 			<tvormov>tv</tvormov>


### PR DESCRIPTION
As mentioned on the roku forum, here's a tiny patch to fix the problem I hit with an "&" in the subtitle of a program. 

Thanks for this app, I'm looking forward to using it quite a bit. 
