### PR TITLE
Fix for file deletion

### DIFF
--- a/mythroku/mythtv.php
+++ b/mythroku/mythtv.php
@@ -9,6 +9,7 @@ print "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
 	  <banner_ad sd_img=\"" . $WebServer . "/" . $MythRokuDir . "/images/mythtv_logo_SD.png\" hd_img=\"" . $WebServer . "/" . $MythRokuDir . "/images/mythtv_logo_SD.png\"/>
 
 	<category title=\"TV\" description=\"MythTV TV\" sd_img=\"" . $WebServer . "/" . $MythRokuDir . "/images/Mythtv_tv.png\" hd_img=\"" . $WebServer . "/" . $MythRokuDir . "/images/Mythtv_tv.png\">
+		<categoryLeaf title=\"Record Group\" description=\"\" feed=\"" . $WebServer . "/" . $MythRokuDir . "/mythtv_tv_xml.php?sort=recgroup\"/> 
 		<categoryLeaf title=\"Date\" description=\"\" feed=\"" . $WebServer . "/" . $MythRokuDir . "/mythtv_tv_xml.php?sort=date\"/> 
 		<categoryLeaf title=\"Title\" description=\"\" feed=\"" . $WebServer . "/" . $MythRokuDir . "/mythtv_tv_xml.php?sort=title\"/> 
 		<categoryLeaf title=\"Genre\" description=\"\" feed=\"" . $WebServer . "/" . $MythRokuDir . "/mythtv_tv_xml.php?sort=genre\"/> 

--- a/mythroku/mythtv_tv_del.php
+++ b/mythroku/mythtv_tv_del.php
@@ -16,7 +16,7 @@ if ($db_found) {
 		$unixt = convert_datetime($mysqltime); 
 		mysql_query("DELETE FROM recorded WHERE starttime = '$mysqltime' ");
 
-		$files = glob('../data/recordings/*' . $unixt . '*');
+		$files = glob('../data/recordings/*' . $_GET['basename'] . '*');
 		array_walk($files,'myunlink');
 
 		

--- a/mythroku/mythtv_tv_xml.php
+++ b/mythroku/mythtv_tv_xml.php
@@ -17,6 +17,8 @@ if ($db_found) {
 		$SQL = "SELECT * FROM recorded ORDER BY starttime DESC";
 	}elseif (isset($_GET['sort']) && $_GET['sort'] == 'title'){
 		$SQL = "SELECT * FROM recorded ORDER BY title ASC";
+	}elseif (isset($_GET['sort']) && $_GET['sort'] == 'recgroup'){
+		$SQL = "SELECT * FROM recorded ORDER BY recgroup ASC";
 	}elseif (isset($_GET['sort']) && $_GET['sort'] == 'genre'){
 		$SQL = "SELECT * FROM recorded ORDER BY category ASC";
 	}elseif (isset($_GET['sort']) && $_GET['sort'] == 'channel'){

--- a/mythroku/mythtv_tv_xml.php
+++ b/mythroku/mythtv_tv_xml.php
@@ -63,7 +63,7 @@ while ($db_field = mysql_fetch_assoc($result)) {
 		//print out all the records in xml format for roku to read 
 		print "	
 		<item sdImg=\"" . $WebServer . "/tv/get_pixmap/" . $db_field['hostname'] . "/" . $db_field['chanid'] ."/" . convert_datetime($db_field['starttime']) . "/100/75/-1/" . $db_field['basename'] .".100x75x-1.png\" hdImg=\"" . $WebServer . "/tv/get_pixmap/" . $db_field['hostname'] . "/" . $db_field['chanid'] . "/" . convert_datetime($db_field['starttime']) . "/100/75/-1/" . $db_field['basename'] . ".100x75x-1.png\">
-			<title>" . $db_field['title'] . "</title>
+			<title>" . htmlspecialchars(preg_replace('/[^(\x20-\x7F)]*/','', $db_field['title'] )) . "</title>
 			<contentId>" . $counter++ . "</contentId>
 			<contentType>TV</contentType>
 			<contentQuality>". $RokuDisplayType . "</contentQuality>
@@ -74,7 +74,7 @@ while ($db_field = mysql_fetch_assoc($result)) {
 				<streamUrl>" . $WebServer . "/pl/stream/" . $db_field['chanid'] . "/" . convert_datetime($db_field['starttime']) . ".mp4</streamUrl>
 			</media>
 			<synopsis>" . htmlspecialchars(preg_replace('/[^(\x20-\x7F)]*/','', $db_field['description'] )) . "</synopsis>
-			<genres>" . $db_field['category'] . "</genres>
+			<genres>" . htmlspecialchars(preg_replace('/[^(\x20-\x7F)]*/','', $db_field['category'] )) . "</genres>
 			<subtitle>" . htmlspecialchars(preg_replace('/[^(\x20-\x7F)]*/','', $db_field['subtitle'] )) . "</subtitle>
 			<runtime>" . $ShowLength . "</runtime>
 			<date>" . date("F j, Y, g:i a", convert_datetime($db_field['starttime'])) . "</date>

--- a/mythroku/mythtv_tv_xml.php
+++ b/mythroku/mythtv_tv_xml.php
@@ -73,7 +73,7 @@ while ($db_field = mysql_fetch_assoc($result)) {
 			</media>
 			<synopsis>" . htmlspecialchars(preg_replace('/[^(\x20-\x7F)]*/','', $db_field['description'] )) . "</synopsis>
 			<genres>" . $db_field['category'] . "</genres>
-			<subtitle>" . $db_field['subtitle'] . "</subtitle>
+			<subtitle>" . htmlspecialchars(preg_replace('/[^(\x20-\x7F)]*/','', $db_field['subtitle'] )) . "</subtitle>
 			<runtime>" . $ShowLength . "</runtime>
 			<date>" . date("F j, Y, g:i a", convert_datetime($db_field['starttime'])) . "</date>
 			<tvormov>tv</tvormov>

--- a/mythroku/mythtv_tv_xml.php
+++ b/mythroku/mythtv_tv_xml.php
@@ -79,7 +79,7 @@ while ($db_field = mysql_fetch_assoc($result)) {
 			<runtime>" . $ShowLength . "</runtime>
 			<date>" . date("F j, Y, g:i a", convert_datetime($db_field['starttime'])) . "</date>
 			<tvormov>tv</tvormov>
-			<delcommand>" . $WebServer . "/mythroku/mythtv_tv_del.php?recordid=" . convert_datetime($db_field['starttime']) . "</delcommand>
+			<delcommand>" . $WebServer . "/mythroku/mythtv_tv_del.php?recordid=" . convert_datetime($db_field['starttime']) . "&amp;basename=" . RemoveExtension($db_field['basename']) . "</delcommand>
 		</item>";	
 	}
 }


### PR DESCRIPTION
I noticed that the actual files were not getting deleted. Not sure if this is a configuration option somewhere in the backend, but the files on disk on my instance are not named using the recordid so it wasn't finding the correct files and just deleting the DB entries. This commit ( 381ac41b ) addresses that for me. As I mention in the commit message, probably could be done by a DB read in the delete script, but it seemed more efficient to just have the basename added to the delete url in the listing xml since that info was already available.
